### PR TITLE
Receive and mint

### DIFF
--- a/pydano/transaction/composite_transaction.py
+++ b/pydano/transaction/composite_transaction.py
@@ -1,0 +1,21 @@
+from pydano.transaction.transaction import Transaction, TransactionConfig, CalculateMinFeeTransaction
+
+class AdjustFeeTransaction:
+    def __init__(self, transaction: Transaction, transaction_config: TransactionConfig):
+        self.transaction = transaction
+        self.transaction_config = transaction_config
+
+    def run_transaction(self):
+        self.transaction.run_transaction()
+        calc_fee = CalculateMinFeeTransaction(self.transaction_config, self.transaction.transaction_file, testnet=self.transaction.testnet)
+        fees_command_stdout = calc_fee.run_transaction()
+        min_fees = fees_command_stdout.stdout.split()[0].strip()
+        if type(min_fees) == bytes:
+            min_fees = min_fees.decode()
+        if not min_fees.isnumeric():
+            raise ValueError("Error getting minfees")
+        min_fees = int(min_fees)
+        self.transaction.transaction_config.fees = min_fees
+        self.transaction.run_transaction()
+        return self.transaction
+

--- a/pydano/transaction/mint_transaction.py
+++ b/pydano/transaction/mint_transaction.py
@@ -1,4 +1,4 @@
-from pydano.transaction.transaction import BuildTransaction, TransactionConfig
+from pydano.transaction.transaction import BuildTransaction, BuildRawTransaction, TransactionConfig
 from pydano.transaction.policy_transaction import PolicyIDTransaction
 
 class MintTransaction(BuildTransaction):
@@ -14,6 +14,25 @@ class MintTransaction(BuildTransaction):
     def build_base_transaction(self):
         command = self.base_command
         command = self.apply_blockchain(command)
+        command.extend(self.transaction_config.input_utxos_args())
+        command.extend(self.transaction_config.out_tx_args())
+        command.extend(self.transaction_config.mint_args(self.minting_script_file, self.metadata_json_file))
+        return command
+
+# TODO: Maybe we can use multiple inheritance here.
+class MintRawTransaction(BuildRawTransaction):
+
+    def __init__(self, transaction_config: TransactionConfig, testnet: bool = True, minting_script_file='', metadata_json_file=None):
+        super().__init__(transaction_config, testnet)
+        if not minting_script_file:
+            raise ValueError("Minting requires Minting script")
+        self.minting_script_file = minting_script_file
+        self.metadata_json_file = metadata_json_file
+        self.policyID = PolicyIDTransaction(testnet).policyID(self.minting_script_file)
+
+    def build_base_transaction(self):
+        command = self.base_command
+        command.extend(['--fee', str(self.transaction_config.fees)])
         command.extend(self.transaction_config.input_utxos_args())
         command.extend(self.transaction_config.out_tx_args())
         command.extend(self.transaction_config.mint_args(self.minting_script_file, self.metadata_json_file))

--- a/pydano/transaction/transaction.py
+++ b/pydano/transaction/transaction.py
@@ -26,6 +26,8 @@ class TransactionConfig:
         self.min_utxo = min_utxo
         self.min_change_utxo = min_change_utxo
         self.testnet = testnet
+        self.fees = 0
+        self.fee_payer_address = None
 
 
     """
@@ -60,12 +62,15 @@ class TransactionConfig:
         asset_name: this can be lovlace/native token or name of the nft.
         asset_quanity: quantity of token/lovelace to transfer. Should be 1 in case of NFTs..
     """
-    def add_tx_out(self, out_address: str, asset_name: str, asset_quantity: int):
+    def add_tx_out(self, out_address: str, asset_name: str, asset_quantity: int, fee_payer = False):
         out = {'out_address': out_address,
                 'name': asset_name,
                 'quantity': asset_quantity
                 }
+
         self.output_txs[out_address].append(out)
+        if fee_payer:
+            self.fee_payer_address = out_address
         return len(self.output_txs)
 
     def add_mint(self, out_address: str, policyid: str, token_name: str):
@@ -94,13 +99,15 @@ class TransactionConfig:
             # It is mandatory to have one ADA transaction 
             # So add min_utxo ada to each output tx
             if out_assets[0]['name'].lower() == 'lovelace':
-                tx_out_config = ""
-                tx_out_config += '+' + str(out_assets[0]['quantity'])
+                quantity = out_assets[0]['quantity']
                 index = 1
             else:
-                tx_out_config = ""
-                tx_out_config += '+' + str(self.min_utxo)
+                quantity = self.min_utxo
                 index = 0
+            # Deduct the fee from out_transaction which is supposed to pay fees
+            if out_assets[0]['out_address'] == self.fee_payer_address:
+                quantity -= self.fees
+            tx_out_config = '+' + str(quantity)
             for asset in out_assets[index:]:
                 if (asset['name'] not in self.mints) and (asset['name'] not in self.available_tokens or self.available_tokens[asset['name']] < asset['quantity']):
                     raise ValueError(f"Trying to spend asset {asset['name']}, which is not available in {asset}, {out_assets}")
@@ -170,6 +177,8 @@ class Transaction(CardanoCli):
 
 class BuildTransaction(Transaction):
 
+    raw = False
+
     def __init__(self, transaction_config: TransactionConfig, testnet: bool = True):
         super().__init__(transaction_config, testnet)
         self.protocol_file = ProtocolParam(testnet).protocol_params()
@@ -180,7 +189,10 @@ class BuildTransaction(Transaction):
 
     def build_base_transaction(self):
         command = self.base_command
-        command = self.apply_blockchain(command)
+        if not self.raw:
+            command = self.apply_blockchain(command)
+        else:
+            command.extend(['--fee', str(self.transaction_config.fees)])
         command.extend(self.transaction_config.input_utxos_args())
         command.extend(self.transaction_config.out_tx_args())
         return command
@@ -194,12 +206,43 @@ class BuildTransaction(Transaction):
 
     def prepare_transaction(self):
         base_transaction = self.build_base_transaction()
-        base_transaction.append('--change-address')
-        base_transaction.append(self.transaction_config.change_address)
+        if not self.raw:
+            base_transaction.append('--change-address')
+            base_transaction.append(self.transaction_config.change_address)
         base_transaction.append("--protocol-params-file")
         base_transaction.append(self.protocol_file)
         complete_trans =  self.build_output_file(base_transaction)
         self.prepared_transaction =  complete_trans
+
+class BuildRawTransaction(BuildTransaction):
+
+    raw = True
+
+    @property
+    def base_command(self):
+        return ["cardano-cli", "transaction", "build-raw", "--alonzo-era"]
+
+class CalculateMinFeeTransaction(Transaction):
+
+    def __init__(self, transaction_config: TransactionConfig, raw_transaction: str, testnet: bool = True):
+        super().__init__(transaction_config, testnet)
+        self.raw_transaction = raw_transaction
+        self.protocol_file = ProtocolParam(testnet).protocol_params()
+
+    @property
+    def base_command(self):
+        return ["cardano-cli", "transaction", "calculate-min-fee"]
+
+    def prepare_transaction(self):
+        command = self.base_command
+        command.append('--tx-body-file')
+        command.append(self.raw_transaction)
+        len_output_txs = len(self.transaction_config.output_txs)
+        command.extend(['--tx-in-count', '1', '--tx-out-count', str(len_output_txs), '--witness-count', str(1 + len_output_txs)])
+        command = self.apply_blockchain(command)
+        command.append("--protocol-params-file")
+        command.append(self.protocol_file)
+        self.prepared_transaction = command
 
 class SignTransaction(Transaction):
 


### PR DESCRIPTION

    Intial working prototype of receive_and_mint, but we need to build out
    using raw transactions instead of this, as we don't want to leave any
    money into change address.

    Added support to do raw transaction and use it in receive_and_mint
    
    1. Implemented building raw transaction and raw mint transaction
    2. Wrapped raw transaction, calculate min fees, raw transaction in a
       composite wrapper transaction (which is mostly a helper and doesn't
               do much)
    3. Implemented the fee pay mechanism in transaction config.
    4. updated the pydano_cli to use new method which can spend the whole
       utxo.

    Get money sender address from blockfrost.
    
    Improve if multiple lovelace transaction for single addresses are added.
    Consolidate the assets quanity before building the out transaction.
